### PR TITLE
Added magnetic traction to silicons

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -61,6 +61,8 @@
 	var/tonermax = 40
 	var/jetpackoverlay = 0
 
+	var/magpulse = 0
+
 /mob/living/silicon/robot/New(loc)
 
 	if(ismommi(src))
@@ -257,6 +259,15 @@
 	set category = "Robot Commands"
 	set name = "Show Alerts"
 	robot_alerts()
+
+/mob/living/silicon/robot/verb/cmd_toggle_magpulse()
+	set category = "Robot Commands"
+	set name = "Toggle magnetic traction"
+	magpulse = !magpulse
+	if(magpulse)
+		src << "<span class='notice'>Switched on magnetic traction.</span>"
+	else
+		src << "<span class='notice'>Switched off magnetic traction.</span>"
 
 //for borg hotkeys, here module refers to borg inv slot, not core module
 /mob/living/silicon/robot/verb/cmd_toggle_module(module as num)

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -6,10 +6,13 @@
 	if(..())	return 1
 	return 0
 
+/mob/living/silicon/robot/mob_negates_gravity()
+	return magpulse
+
  //No longer needed, but I'll leave it here incase we plan to re-use it.
 /mob/living/silicon/robot/movement_delay()
 	var/tally = 0 //Incase I need to add stuff other than "speed" later
 
-	tally = speed
+	tally = speed+2*magpulse	//2 when traction on, 0 when off
 
 	return tally+config.robot_delay


### PR DESCRIPTION
Cyborgs and MoMMIs now have "Toggle magnetic traction" for 0G work under robot commands. This has the same effect as a pair of magboots on a human.