### PR TITLE
Fixes SMES-cells showing wrong value for powernet load

### DIFF
--- a/code/game/machinery/computer/RCON_Console.dm
+++ b/code/game/machinery/computer/RCON_Console.dm
@@ -131,7 +131,7 @@
 		"input_val" = round(SMES.input_level),
 		"output_set" = SMES.output_attempt,
 		"output_val" = round(SMES.output_level),
-		"output_load" = round(SMES.output_used),
+		"output_load" = round(SMES.output_shown),
 		"RCON_tag" = SMES.RCon_tag
 		)))
 

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -814,7 +814,7 @@ Code:
 					"inputting" = SMES.inputting,
 					"output_set" = SMES.output_attempt,
 					"output_val" = round(SMES.output_level/1000, 0.1),
-					"output_load" = round(SMES.output_used/1000, 0.1),
+					"output_load" = round(SMES.output_shown/1000, 0.1),
 					"RCON_tag" = SMES.RCon_tag
 					)))
 

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -81,6 +81,9 @@
 	if(netexcess > 100 && nodes && nodes.len)		// if there was excess power last cycle
 		for(var/obj/machinery/power/smes/S in nodes)	// find the SMESes in the network
 			S.restore()				// and restore some of the power that was used
+	else
+		for(var/obj/machinery/power/smes/S in nodes)
+			S.output_shown = S.output_used			// If there's no excess restore() doesn't get called
 
 	//updates the viewed load (as seen on power computers)
 	viewload = 0.8*viewload + 0.2*load

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -26,6 +26,7 @@
 	var/output_level = 50000 // amount of power the SMES attempts to output
 	var/output_level_max = 200000 // cap on output_level
 	var/output_used = 0 // amount of power actually outputted. may be less than output_level if the powernet returns excess power
+	var/output_shown = 0 // Required because output_used updates at least twice a tick, and only once with the correct value
 	machine_flags = CROWDESTROY | SCREWTOGGLE | REPLACEPARTS
 
 	var/obj/machinery/power/terminal/terminal = null
@@ -241,11 +242,13 @@
 
 		if(output_used < 0.0001)			// either from no charge or set to 0
 			outputting = 0
+			output_shown = 0
 			investigate_log("lost power and turned <font color='red'>off</font>","singulo")
 	else if(output_attempt && charge > output_level && output_level > 0)
 		outputting = 1
 	else
 		output_used = 0
+		output_shown = 0
 
 	// only update icon if state changed
 	if(last_disp != chargedisplay() || last_chrg != inputting || last_onln != outputting)
@@ -261,6 +264,7 @@
 
 	if(!outputting)
 		output_used = 0
+		output_shown = 0
 		return
 
 	var/excess = powernet.netexcess		// this was how much wasn't used on the network last ptick, minus any removed by other SMESes
@@ -277,6 +281,7 @@
 	powernet.netexcess -= excess		// remove the excess from the powernet, so later SMESes don't try to use it
 
 	output_used -= excess
+	output_shown = output_used
 
 	if(clev != chargedisplay() ) //if needed updates the icons overlay
 		update_icon()
@@ -329,7 +334,7 @@
 		"outputting" = outputting,
 		"outputLevel" = output_level,
 		"outputLevelMax" = output_level_max,
-		"outputUsed" = output_used
+		"outputUsed" = output_shown
 	)
 
 	return data


### PR DESCRIPTION
#76 
SMES-cells used to always show the power output they were set to instead of the actual load.