### PR TITLE
Meeseeks now enter crit.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -302,7 +302,7 @@
 		else
 			H << "<span class='danger'>[pick("KILL YOUR MASTER!","YOU CAN'T TAKE IT ANYMORE!","EVERYTHING IS PAIN!")]</span>"
 			H.say("KILL ME!!!!!")
-	if(H.health < 150)
+	if(H.health < -50)
 		H.adjustOxyLoss(-H.getOxyLoss())
 		H.adjustToxLoss(-H.getToxLoss())
 		H.adjustFireLoss(-H.getFireLoss())


### PR DESCRIPTION
You need a negative health number or meeseeks will never go into crit.

The number should be safely distant from the -100 threshold for death, too.

I think -50 was even the intended figure.