### PR TITLE
normalize floor tile materials

### DIFF
--- a/code/game/objects/items/stacks/tiles/plasteel.dm
+++ b/code/game/objects/items/stacks/tiles/plasteel.dm
@@ -7,7 +7,7 @@
 	icon_state = "tile"
 	w_class = 3.0
 	force = 6.0
-	materials = list(MAT_METAL=937.5)
+	materials = list(MAT_METAL=MINERAL_MATERIAL_AMOUNT/4)  // 4 tiles per metal sheet.
 	throwforce = 10.0
 	throw_speed = 3
 	throw_range = 7


### PR DESCRIPTION
Floor tiles had much more metal than 1/4 of a sheet per tile in its materials list.
Answer to https://github.com/Zaers/-tg-station/issues/95