### PR TITLE
Revert/fix typo in chem synth

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -472,31 +472,32 @@ to destroy them and players will be able to make replacements.
 
 /obj/item/weapon/circuitboard/chem_dispenser/attackby(obj/item/I as obj, mob/user as mob, params)
 	if(istype(I,/obj/item/weapon/screwdriver))
-		input("Current mode is set to: [finish_type]","Circuitboard interface")in list("Advanced Chem Synthesizer","Chemical dispenser", "Booze dispenser", "Soda dispenser", "Cancel")
-		switch( finish_type)
-			if("Advanced Chem Synthsizer")
-				name = "circuit board (Advanced Chem Synthsizer)"
+		var/board_choice = alert("Current mode is set to: [finish_type]","Circuitboard interface","Advanced Chem Synthesizer","Chemical Dispenser", "Booze Dispenser", "Soda Dispenser", "Cancel")
+		switch( board_choice )
+			if("Advanced Chem Synthesizer")
+				name = "circuit board (Advanced Chem Synthesizer)"
 				build_path = /obj/machinery/chem_dispenser/constructable/synth
 				finish_type = "advanced chem synthesizer"
-			if("Chemical dispenser")
+				return
+			if("Chemical Dispenser")
 				name = "circuit board (Portable Chem Dispenser)"
 				build_path = /obj/machinery/chem_dispenser/constructable
 				finish_type = "chemical dispenser"
-
-			if("Booze dispenser")
+				return
+			if("Booze Dispenser")
 				name = "circuit board (Portable Booze Dispenser)"
 				build_path = /obj/machinery/chem_dispenser/constructable/booze
 				finish_type = "booze dispenser"
-
-			if("Soda dispenser")
+				return
+			if("Soda Dispenser")
 				name = "circuit board (Portable Soda Dispenser)"
 				build_path = /obj/machinery/chem_dispenser/constructable/drinks
 				finish_type = "soda dispenser"
-
+				return
 			if("Cancel")
 				return
 			else
-				user << "Invalid input, try again"
+				user << "[board_choice]: Invalid input, try again"
 	return
 
 


### PR DESCRIPTION
Screwdriver interaction with the PCD broke with the addition of the advanced chem synth.

This should restore functionality.