### PR TITLE
use_power in Valve/Gate

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -17,6 +17,7 @@ Passive gate is similar to the regular pump except:
 
 	var/on = 0
 	var/target_pressure = ONE_ATMOSPHERE
+	use_power = 0
 
 	var/frequency = 0
 	var/id = null

--- a/code/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -6,6 +6,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	icon_state = "mvalve_map"
 	name = "manual valve"
 	desc = "A pipe valve"
+	use_power = 0
 
 	can_unwrench = 1
 
@@ -60,6 +61,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	desc = "A digitally controlled valve."
 	icon_state = "dvalve_map"
 	valve_type = "d"
+	use_power = 1
 
 /obj/machinery/atmospherics/components/binary/valve/digital/attack_ai(mob/user)
 	return src.attack_hand(user)


### PR DESCRIPTION
Valve and Gate were requiring power.  Now only the digital valve requires power, and the gate and manual valve work unpowered.