### PR TITLE
Fix polymorph/meeseeks bug

### DIFF
--- a/code/game/objects/items/devices/meeseeksbox.dm
+++ b/code/game/objects/items/devices/meeseeksbox.dm
@@ -33,9 +33,8 @@
 		if(candidates.len)
 			var/mob/dead/observer/C = pick(candidates)
 			var/mob/living/carbon/human/M = new /mob/living/carbon/human
-			hardset_dna(M, null, null, null, null, /datum/species/golem/meeseeks)
+			hardset_dna(M, null, null, "Mr. Meeseeks ([rand(1, 1000)])", null, /datum/species/golem/meeseeks)
 			M.set_cloned_appearance()
-			M.real_name = text("Mr. Meeseeks ([rand(1, 1000)])")
 			M.job = "Mr. Meeseeks"
 			M.dna.species.auto_equip(M)
 			M.loc = user.loc

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -420,6 +420,9 @@
 	var/mob/living/carbon/human/MST = master
 
 	if((MST && MST.stat == DEAD) || !MST)
+		if(findtextEx(H.real_name, "Mr. Meeseeks (") == 0) // This mob has no business being a meeseeks
+			hardset_dna(H, null, null, null, null, /datum/species/human )
+			return // get me the hell out of here.
 		for(var/mob/M in viewers(7, H.loc))
 			M << "<span class='warning'><b>[src]</b> smiles and disappers with a low pop sound.</span>"
 		H.drop_everything()


### PR DESCRIPTION
Humans that had their species randomly changed could become a Meeseeks and despawn on the next tick.

This change should prevent the outcome in most realistic scenarios.

Anyone naming themselves something with "Mr.Meeseeks (" in it will still despawn, but it's probably going to be a clown or mime, so who cares.