### PR TITLE
MoMMI killswitch edit

### DIFF
--- a/code/game/machinery/mommi_spawner.dm
+++ b/code/game/machinery/mommi_spawner.dm
@@ -147,6 +147,9 @@
 		M.killswitch = 1
 		M.allowed_z = 4
 */
+
+	M.initialize_killswitch()
+
 	//M.cell = locate(/obj/item/weapon/cell) in contents
 	//M.cell.loc = M
 	user.loc = M//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -76,7 +76,7 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 
 
 
-	initialize_killswitch() //make the explode if they leave their z-level
+//	initialize_killswitch() //make the explode if they leave their z-level. Only for spawner-MoMMIs now
 
 
 	if(connected_ai)


### PR DESCRIPTION
MoMMIs don't have a killswitch by default, only ones spawned by spawners do