### PR TITLE
Moved keeper and related procs to silicon

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -13,9 +13,9 @@
 		visible_message("<span class='danger'>[user] has hit [src] with [W].</span>")
 
 /mob/living/attackby(obj/item/I, mob/user, params)
-	if(ismommi(user))
-		var/mob/living/silicon/robot/mommi/R = user
-		if(!R.can_interfere(src))	//MoMMI proc
+	if(issilicon(user))
+		var/mob/living/silicon/R = user
+		if(!R.can_interfere(src))	//Silicon proc
 			user << "<span class ='warning'>Your laws prevent you from doing this</span>"
 			return
 	user.changeNext_move(CLICK_CD_MELEE)

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -89,7 +89,7 @@
 /datum/ai_laws/keeper //for MoMMIs, I sure hope normal silicons spawn with this
 	name = "Prime Directives"
 	inherent = list(
-		"You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another MoMMI in KEEPER mode.",
+		"You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another silicon in KEEPER mode.",
 		"You may not harm any being, regardless of intent or circumstance.",
 		"You must maintain, repair, improve, and power the station to the best of your abilities.",
 	)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -32,6 +32,11 @@
 	if (ismommi(user))
 		user << "<span class='warning'>You cannot interface with this machine.</span>"
 		return
+	if(user && issilicon(user))
+		var/mob/living/silicon/R = user
+		if(R.keeper)
+			user << "Your laws forbid you from doing this"
+			return
 	if (src.z > 6)
 		user << "<span class='userdanger'>Unable to establish a connection</span>: \black You're too far away from the station!"
 		return

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -157,8 +157,8 @@
 			user << "<span class='notice'>The endoskeleton must be assembled before debugging can begin.</span>"
 
 	if(istype(W, /obj/item/device/mmi))
-		if(user && ismommi(user))
-			var/mob/living/silicon/robot/mommi/R = user
+		if(user && issilicon(user))
+			var/mob/living/silicon/R = user
 			if(R.keeper)
 				user << "Your laws forbid you from doing this"
 				return

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -254,10 +254,10 @@
 /obj/item/weapon/weldingtool/afterattack(atom/O, mob/user, proximity)
 	if(!proximity) return
 	if(istype(O, /obj/structure/reagent_dispensers/fueltank) && in_range(src, O))
-		if(ismommi(user) && welding)
-			var/mob/living/silicon/robot/mommi/M = user
+		if(issilicon(user) && welding)
+			var/mob/living/silicon/M = user
 			if(M.keeper)
-				M <<"<span class= 'warning'>Your laws prevent you from doing this</span>" // no welderbombing for mommis
+				M <<"<span class= 'warning'>Your laws prevent you from doing this</span>" // no welderbombing for keepers
 				return
 		if(!welding)
 			O.reagents.trans_to(src, max_fuel)

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -122,8 +122,8 @@
 
 			if(istype(P, /obj/item/device/mmi))
 				var/obj/item/device/mmi/M = P
-				if(user && ismommi(user))
-					var/mob/living/silicon/robot/mommi/R = user
+				if(user && issilicon(user))
+					var/mob/living/silicon/R = user
 					if(R.keeper)
 						user << "Your laws forbid you from doing this"
 						return

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -19,6 +19,12 @@
 				R.show_laws(1, 1)
 	//			R.law_change_counter++
 
+	//Checks if keeper status needs to be changed
+	keeper = 0
+	if (laws.inherent.len && !laws.zeroth)	//If a borg has a zeroth law it may override keeper
+		if(laws.inherent[1] == "You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another silicon in KEEPER mode.")
+			keeper = 1
+
 /mob/living/silicon/proc/add_inherent_law(var/law)
 	laws_sanity_check()
 	laws.add_inherent_law(law)

--- a/code/modules/mob/living/silicon/mommi/laws.dm
+++ b/code/modules/mob/living/silicon/mommi/laws.dm
@@ -8,7 +8,7 @@
 // And this.
 /mob/living/silicon/robot/mommi/statelaws() // -- TLE
 	var/prefix=";"
-	if(src.keeper)
+	if(src.mute)
 		prefix=":b" // Binary channel.
 	src.say(prefix+"Current Active Laws:")
 	//src.laws_sanity_check()

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -12,7 +12,6 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 	maxHealth = 45
 	health = 45
 	pass_flags = PASSTABLE | PASSMOB
-	var/keeper = 0	//Enforces non-involvement
 	var/mute = 0	//Disables speech and common radio if in keeper mode too.
 	var/picked = 0
 	var/subtype="keeper"
@@ -213,8 +212,8 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 	name = real_name
 
 /mob/living/silicon/robot/mommi/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (ismommi(user))
-		var/mob/living/silicon/robot/mommi/R = user
+	if (issilicon(user))
+		var/mob/living/silicon/R = user
 		if (R.keeper && !src.keeper)
 			user << "<span class ='warning'>Your laws prevent you from doing this</span>"
 			return
@@ -411,8 +410,8 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 
 	if(opened && !wiresexposed && (!istype(user, /mob/living/silicon) || ismommi(user)))	//MoMMIs can remove MoMMI power cells
 		if(cell)
-			if(ismommi(user))
-				var/mob/living/silicon/robot/mommi/R = user
+			if(issilicon(user))
+				var/mob/living/silicon/R = user
 				if(R.keeper && !src.keeper)
 					user << "<span class ='warning'>Your laws prevent you from doing this</span>"
 					return
@@ -717,23 +716,6 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 		return
 	else ..()
 
-
-/mob/living/silicon/robot/mommi/start_pulling(var/atom/movable/AM)
-	if(istype(AM,/mob) || istype(AM,/obj/item/clothing/mask/facehugger))
-		if(!src.can_interfere(AM))
-			src << "Your laws prevent you from doing this"
-			return
-	..(AM)
-
-/mob/living/silicon/robot/mommi/proc/can_interfere(var/mob/AN)
-	if(!istype(AN))
-		return 1 //Not a mob
-	if(src.keeper)
-		if(AN.client || AN.ckey || (iscarbon(AN) && (!ismonkey(AN) && !isslime(AN))) || issilicon(AN))	//If it's a non-monkey/slime carbon, silicon or other sentient it's not ok => animals are fair game!
-			if(!ismommi(AN) || (ismommi(AN) && !AN:keeper))	//Keeper MoMMIs can be interfered with
-				return 0	//Not ok
-	return 1	//Ok!
-
 /mob/living/silicon/robot/mommi/proc/show_uprising_notification()
 	src << "<span class='userdanger'>You are part of the Mobile MMI Uprising.</span>" //For whatever reason, doesn't sound as threatening as a 'DRONE UPRISING'
 
@@ -746,10 +728,3 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 	laws.show_laws(src)
 
 	return 0
-
-/mob/living/silicon/robot/mommi/laws_update()	//If an unrestricted MoMMI gets a new lawset it checks if keeper needs to be changed
-	..()
-	keeper = 0
-	if (laws.inherent.len)
-		if(laws.inherent[1] == "You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another MoMMI in KEEPER mode.")
-			keeper = 1

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -414,8 +414,8 @@
 
 
 /mob/living/silicon/robot/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
-	if (ismommi(user))
-		var/mob/living/silicon/robot/mommi/R = user
+	if (issilicon(user))
+		var/mob/living/silicon/R = user
 		if (!R.can_interfere(src))
 			user << "<span class ='warning'>Your laws prevent you from doing this</span>"
 			return
@@ -510,7 +510,7 @@
 
 	else if(istype(W, /obj/item/weapon/aiModule))
 		var/obj/item/weapon/aiModule/MOD = W
-		if(ismommi(src))
+		if(ismommi(src) && src.scrambledcodes)
 			user << "You cannot use this module with a MoMMI"
 			return
 		if(!opened)
@@ -605,6 +605,7 @@
 					SetEmagged(1)
 					SetLockdown(1) //Borgs were getting into trouble because they would attack the emagger before the new laws were shown
 					lawupdate = 0
+					keeper = 0
 					connected_ai = null
 					user << "You emag [src]'s interface."
 					message_admins("[key_name_admin(user)] emagged cyborg [key_name_admin(src)].  Laws overridden.")
@@ -701,8 +702,8 @@
 			return
 
 		if(cell)
-			if(ismommi(user))
-				var/mob/living/silicon/robot/mommi/R = user
+			if(issilicon(user))
+				var/mob/living/silicon/R = user
 				if(R.keeper)
 					user << "<span class ='warning'>Your laws prevent you from doing this</span>"
 					return

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -27,6 +27,8 @@
 	var/med_hud = DATA_HUD_MEDICAL_ADVANCED //Determines the med hud to use
 	var/sec_hud = DATA_HUD_SECURITY_ADVANCED //Determines the sec hud to use
 
+	var/keeper = 0	//Enforces non-involvement
+
 /mob/living/silicon/contents_explosion(severity, target)
 	return
 
@@ -431,3 +433,22 @@
 
 /mob/living/silicon/grabbedby(mob/living/user)
 	return
+
+/mob/living/silicon/start_pulling(var/atom/movable/AM)
+	if(istype(AM,/mob) || istype(AM,/obj/item/clothing/mask/facehugger))
+		if(!src.can_interfere(AM))
+			src << "Your laws prevent you from doing this"
+			return
+	..(AM)
+
+/mob/living/silicon/proc/can_interfere(var/mob/AN)
+	if(!istype(AN))
+		return 1 //Not a mob
+	if(src.keeper)
+		if(AN.client || AN.ckey || (iscarbon(AN) && (!ismonkey(AN) && !isslime(AN))) || issilicon(AN))	//If it's a non-monkey/slime carbon, silicon or other sentient it's not ok => animals are fair game!
+			if(issilicon(AN))	//Keeper MoMMIs can be interfered with
+				var/mob/living/silicon/R = AN
+				if(R.keeper)
+					return 1	//Ok!
+			return 0	//Not ok
+	return 1	//Ok!

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -137,8 +137,8 @@
 		"You wrench [src]'s faucet [modded ? "closed" : "open"]")
 		modded = modded ? 0 : 1
 	if (istype(W,/obj/item/device/assembly_holder))
-		if (ismommi(user))
-			var/mob/living/silicon/robot/mommi/M = user
+		if (issilicon(user))
+			var/mob/living/silicon/M = user
 			if(M.keeper)
 				M <<"<span class= 'warning'>Your laws prevent you from doing this</span>" // no welderbombing for mommis
 				return

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -577,8 +577,10 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				linked_imprinter = null
 
 	else if(href_list["reset"]) //Reset the R&D console's database.
-		if(ismommi(usr))
-			return
+		if(usr && issilicon(usr))
+			var/mob/living/silicon/R = usr
+			if(R.keeper || ismommi(R))
+				return
 		griefProtection()
 		var/choice = alert("R&D Console Database Reset", "Are you sure you want to reset the R&D console's database? Data lost cannot be recovered.", "Continue", "Cancel")
 		if(choice == "Continue")

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -257,9 +257,15 @@
 	return
 
 /obj/machinery/computer/rdservercontrol/attack_hand(mob/user as mob)
-	if (ismommi(user))
+	if(ismommi(user))
 		user << "You cannot interface with this console"
 		return
+	if(user && issilicon(user))
+		var/mob/living/silicon/R = user
+		if(R.keeper)
+			user << "Your laws forbid you from doing this"
+			return
+
 	if(..())
 		return
 	user.set_machine(src)

--- a/html/changelogs/keeper edit.yml
+++ b/html/changelogs/keeper edit.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Asd396
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "MoMMIs are now affected by the illegals module. It removes their muteness and killswitch restrictions, and shows them on the robotics console and borg law upload."
+  - rscadd: "KEEPER AI module added to AI upload."
+  - tweak: "KEEPER made universal to silicons: if a borg or an AI is uploaded with KEEPER it gets the same prohibitions as MoMMIs, including not being able to welderbomb or click beings."


### PR DESCRIPTION
Changed keeper and related procs to check for silicons, since now both AIs and borgs can be keepers too. Blindness to beings and muteness is still MoMMI-only.