### PR TITLE
Halloween 2015

### DIFF
--- a/code/modules/events/holiday/halloween.dm
+++ b/code/modules/events/holiday/halloween.dm
@@ -11,7 +11,7 @@
 	for(var/mob/living/carbon/human/H in mob_list)
 		var/obj/item/weapon/storage/backpack/b = locate() in H.contents
 		new /obj/item/weapon/storage/spooky(b)
-		if(H.dna && istype(H.dna.species, /datum/species/human) // mutate humans only. Mutantraces OK for our Halloween party
+		if(H.dna && istype(H.dna.species, /datum/species/human)) // mutate humans only. Mutantraces OK for our Halloween party
 			if(prob(50))
 				hardset_dna(H, null, null, null, null, /datum/species/skeleton)
 			else

--- a/code/modules/events/holiday/halloween.dm
+++ b/code/modules/events/holiday/halloween.dm
@@ -11,7 +11,7 @@
 	for(var/mob/living/carbon/human/H in mob_list)
 		var/obj/item/weapon/storage/backpack/b = locate() in H.contents
 		new /obj/item/weapon/storage/spooky(b)
-		if(H.dna)
+		if(H.dna && istype(H.dna.species, /datum/species/human) // mutate humans only. Mutantraces OK for our Halloween party
 			if(prob(50))
 				hardset_dna(H, null, null, null, null, /datum/species/skeleton)
 			else

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -5,7 +5,7 @@
 /datum/species/human
 	name = "Human"
 	id = "human"
-	roundstart = 1
+	roundstart = 0 // Revert to 1 after Halloween or whatever masquerade.
 	specflags = list(EYECOLOR,HAIR,FACEHAIR,LIPS)
 	use_skintones = 1
 


### PR DESCRIPTION
Remove Human as a choice for roundstart species.  This does not prevent any existing character profile from starting as human.
Transform only ordinary humans into skeletons/zombies.

I believe this is as close to JustL's proposal as can conveniently be done.