### PR TITLE
Sanity in no-master Meeseeks logic

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -456,12 +456,14 @@
 	if((MST && MST.stat == DEAD) || !MST)
 		if(lingseek)
 			return //everything is fine
+		
 		if( H.job != "Mr. Meeseeks" ) // This mob has no business being a meeseeks
+			if( findtext( H.real_name , "Mr. Meeseeks" ) ) // Transformation Sting, eg.
+				make_lingseek(H)
+				return
 			hardset_dna(H, null, null, null, null, /datum/species/human ) // default to human.
 			return // avert lingseeks. get the hell out of here
-		else
-			make_lingseek(H)
-
+		
 		if(!lingseek) //just to be sure
 			for(var/mob/M in viewers(7, H.loc))
 				M << "<span class='warning'><b>[src]</b> smiles and disappers with a low pop sound.</span>"


### PR DESCRIPTION
Defines exit conditions for when other species might be transformed into meeseeks:
1. Both Meeseeks name and species forced will make a mob into a lingseeks.
2. Only species will default the poor mob into being human.